### PR TITLE
Allow testing library with external application without need to publish it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ node_modules
 *.iml
 
 lib
+
+budgetkey-ng2-components-*.tgz

--- a/.npmignore
+++ b/.npmignore
@@ -7,3 +7,6 @@ node_modules
 app
 package-lock.json
 webpack.config.js
+
+install-into.sh
+budgetkey-ng2-components-*.tgz

--- a/install-into.sh
+++ b/install-into.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+current_dir=$(pwd)
+target=$1
+tarball_filename=$(npm pack | tail -n 1)
+
+cd ${target}
+
+npm install --no-save ${current_dir}/${tarball_filename}

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "build:scripts": "tsc -p src",
     "prebuild": "rm -rf lib",
     "build": "npm run build:scripts && npm run build:styles",
-    "prepublish": "npm run build"
+    "prepublish": "npm run build",
+    "install-into": "./install-into.sh"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Related to OpenBudget/budgetkey-ng2-components#5

How to use: run `npm run install-into <path_to_another_project>` and then rebuild project.