### PR TITLE
Asymmetric header

### DIFF
--- a/projects/budgetkey-ng2-components/src/styles/header.less
+++ b/projects/budgetkey-ng2-components/src/styles/header.less
@@ -107,7 +107,7 @@ header {
 
   div.auth-widget{
     margin-right: 5px;
-    margin-left: 5px;
+    margin-left: 2%;
     padding: 0;
     display: block;
   }


### PR DESCRIPTION
I opened an issue here: https://github.com/OpenBudget/budgetkey-ng2-components/issues/30.

This is the first step towards fixing the asymmetric header, by matching the header's left-side margin to the right-side margin (2%).

The second step is on another repo, but part of it used in this repo. I will link those two.